### PR TITLE
Get running on MC 1.18.2

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 ext.platform_name = 'fabric'
 ext.loader_version = '0.13.3'
-ext.fabric_version = '0.46.4+1.18'
+ext.fabric_version = '0.48.0+1.18.2'
 
 apply from: '../project_common.gradle'
 apply from: 'project.gradle'

--- a/fabriquilt/src/main/java/io/vram/frex/pastel/mixin/MixinChunkRebuildTask.java
+++ b/fabriquilt/src/main/java/io/vram/frex/pastel/mixin/MixinChunkRebuildTask.java
@@ -63,9 +63,6 @@ public abstract class MixinChunkRebuildTask implements RenderRegionContext<Block
 	//e -> field_20839 -> this$1
 	@Shadow protected RenderChunk this$1;
 
-	/** Holds block state for use in fluid render. */
-	private BlockState currentBlockState;
-
 	// Below are for RenderRegionBakeListener support
 
 	@Unique
@@ -106,16 +103,6 @@ public abstract class MixinChunkRebuildTask implements RenderRegionContext<Block
 		}
 	}
 
-	/** Capture block state for use in fluid render. */
-	@Redirect(method = "Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask;compile(FFFLnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$CompiledChunk;Lnet/minecraft/client/renderer/ChunkBufferBuilderPack;)Ljava/util/Set;",
-			require = 1, at = @At(value = "INVOKE",
-			target = "Lnet/minecraft/client/renderer/chunk/RenderChunkRegion;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;"))
-	private BlockState onGetBlockState(RenderChunkRegion blockView, BlockPos pos) {
-		final var result = blockView.getBlockState(pos);
-		currentBlockState = result;
-		return result;
-	}
-
 	@Redirect(method = "Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask;compile(FFFLnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$CompiledChunk;Lnet/minecraft/client/renderer/ChunkBufferBuilderPack;)Ljava/util/Set;",
 			require = 1, at = @At(value = "INVOKE",
 			target = "Lnet/minecraft/client/renderer/block/BlockRenderDispatcher;renderBatched(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/BlockAndTintGetter;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZLjava/util/Random;)Z"))
@@ -137,8 +124,8 @@ public abstract class MixinChunkRebuildTask implements RenderRegionContext<Block
 
 	@Redirect(method = "Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask;compile(FFFLnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$CompiledChunk;Lnet/minecraft/client/renderer/ChunkBufferBuilderPack;)Ljava/util/Set;",
 			require = 1, at = @At(value = "INVOKE",
-			target = "Lnet/minecraft/client/renderer/block/BlockRenderDispatcher;renderLiquid(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/BlockAndTintGetter;Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/world/level/material/FluidState;)Z"))
-	private boolean fluidRenderHook(BlockRenderDispatcher renderManager, BlockPos blockPos, BlockAndTintGetter blockView, VertexConsumer vertexConsumer, FluidState fluidState) {
+			target = "Lnet/minecraft/client/renderer/block/BlockRenderDispatcher;renderLiquid(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/BlockAndTintGetter;Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/material/FluidState;)Z"))
+	private boolean fluidRenderHook(BlockRenderDispatcher renderManager, BlockPos blockPos, BlockAndTintGetter blockView, VertexConsumer vertexConsumer, BlockState currentBlockState, FluidState fluidState) {
 		((RenderChunkRegionExt) blockView).frx_getContext().renderFluid(currentBlockState, blockPos, false, FluidModel.get(fluidState.getType()));
 		// we handle all initialization/tracking in render context
 		return false;


### PR DESCRIPTION
# This PR
This pull request does two things, both of which are required to run Minecraft 1.18.2 with FREX installed.

First, this pr changes the signature of `MixinChunkRebuildTask.fluidRenderHook` and its `target` annotation to match the new `BlockRenderDispatcher.renderLiquid` signature, removing the `RenderChunkRegion.getBlockState` redirect in the process, as the information gathered here is now passed directly to `RenderChunkRegion.getBlockState` and thus `MixinChunkRebuildTask.fluidRenderHook`.

Second, this pr updates the fabric-api dependency version to one compatible with 1.18.2.

# Related Issues
This pr fixes #7.