### PR TITLE
Add intermediary name alias for MixinChunkRebuildTask `this$1`

### DIFF
--- a/fabriquilt/src/main/java/io/vram/frex/pastel/mixin/MixinChunkRebuildTask.java
+++ b/fabriquilt/src/main/java/io/vram/frex/pastel/mixin/MixinChunkRebuildTask.java
@@ -61,7 +61,7 @@ import io.vram.frex.pastel.mixinterface.RenderChunkRegionExt;
 @Mixin(targets = "net.minecraft.client.renderer.chunk.ChunkRenderDispatcher$RenderChunk$RebuildTask")
 public abstract class MixinChunkRebuildTask implements RenderRegionContext<BlockAndTintGetter> {
 	//e -> field_20839 -> this$1
-	@Shadow protected RenderChunk this$1;
+	@Shadow(aliases = {"field_20839"}) protected RenderChunk this$1;
 
 	// Below are for RenderRegionBakeListener support
 


### PR DESCRIPTION
# This PR
This pull request adds an alias to the intermediary name of `MixinChunkRebuildTask`'s reference to `RebuildTask`'s reference to its outer class instance. This variable used to be mapped to `this$1` but that mapping seems to have disappeared for some reason. Using an alias here means that if/when the mapping re-appears again, the variable name will not have to be changed back.

# Testing
This fix has been tested in both a dev-environment and a production environment. Both environments failed to load a world prior to this fix, but now do correctly.

# Related Issues
Fixes #9.