### PR TITLE
Null check before using levelRenderer in ShaderConfig

### DIFF
--- a/common/src/main/java/io/vram/frex/api/config/ShaderConfig.java
+++ b/common/src/main/java/io/vram/frex/api/config/ShaderConfig.java
@@ -89,6 +89,6 @@ public interface ShaderConfig {
 	 */
 	@SuppressWarnings("resource")
 	static void invalidateShaderConfig() {
-		Minecraft.getInstance().levelRenderer.allChanged();
+		if (Minecraft.getInstance().levelRenderer != null) Minecraft.getInstance().levelRenderer.allChanged();
 	}
 }


### PR DESCRIPTION
Config providers may want to call this method on events such as a ModMenu interaction, where a levelRenderer instance might not exist.
This PR is a simple workaround for that issue.